### PR TITLE
Rebuild aws c common0619 aws crt cpp01713

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,9 +1,9 @@
 aws_c_common:
-- 0.6.18
+- 0.6.19
 aws_c_event_stream:
 - 0.2.7
 aws_crt_cpp:
-- 0.17.11
+- 0.17.13
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,11 +1,11 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_c_common:
-- 0.6.18
+- 0.6.19
 aws_c_event_stream:
 - 0.2.7
 aws_crt_cpp:
-- 0.17.11
+- 0.17.13
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,9 +1,9 @@
 aws_c_common:
-- 0.6.18
+- 0.6.19
 aws_c_event_stream:
 - 0.2.7
 aws_crt_cpp:
-- 0.17.11
+- 0.17.13
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/migrations/aws_c_common0619.yaml
+++ b/.ci_support/migrations/aws_c_common0619.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_c_common:
+- 0.6.19
+migrator_ts: 1640670427.41896

--- a/.ci_support/migrations/aws_crt_cpp01713.yaml
+++ b/.ci_support/migrations/aws_crt_cpp01713.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_crt_cpp:
+- 0.17.13
+migrator_ts: 1641270425.958111

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,11 +3,11 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '10.12'
 aws_c_common:
-- 0.6.18
+- 0.6.19
 aws_c_event_stream:
 - 0.2.7
 aws_crt_cpp:
-- 0.17.11
+- 0.17.13
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 aws_c_common:
-- 0.6.18
+- 0.6.19
 aws_c_event_stream:
 - 0.2.7
 aws_crt_cpp:
-- 0.17.11
+- 0.17.13
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,9 +1,9 @@
 aws_c_common:
-- 0.6.18
+- 0.6.19
 aws_c_event_stream:
 - 0.2.7
 aws_crt_cpp:
-- 0.17.11
+- 0.17.13
 c_compiler:
 - vs2017
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Remove-Werror-from-compiler-flags.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-sdk-cpp", max_pin="x.x.x") }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes https://github.com/conda-forge/aws-sdk-cpp-feedstock/pull/370
Closes https://github.com/conda-forge/aws-sdk-cpp-feedstock/pull/373
<!--
Please add any other relevant info below:
-->
Not sure why, but the `aws_c_common0619` and `aws_crt_cpp01713` migrations depend on each other. This PR just combines them into one.