### PR TITLE
Refresh

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
-- 0.8.2
+- 0.6.2
 aws_c_event_stream:
-- 0.2.15
+- 0.2.7
 c_compiler:
 - gcc
 c_compiler_version:
@@ -27,3 +27,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,9 +1,9 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_c_common:
-- 0.8.2
+- 0.6.2
 aws_c_event_stream:
-- 0.2.15
+- 0.2.7
 c_compiler:
 - gcc
 c_compiler_version:
@@ -31,3 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
-- 0.8.2
+- 0.6.2
 aws_c_event_stream:
-- 0.2.15
+- 0.2.7
 c_compiler:
 - gcc
 c_compiler_version:
@@ -27,3 +27,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,9 +3,9 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '10.12'
 aws_c_common:
-- 0.8.2
+- 0.6.2
 aws_c_event_stream:
-- 0.2.15
+- 0.2.7
 c_compiler:
 - clang
 c_compiler_version:
@@ -29,3 +29,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,9 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 aws_c_common:
-- 0.8.2
+- 0.6.2
 aws_c_event_stream:
-- 0.2.15
+- 0.2.7
 c_compiler:
 - clang
 c_compiler_version:
@@ -27,3 +27,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
-- 0.8.2
+- 0.6.2
 aws_c_event_stream:
-- 0.2.15
+- 0.2.7
 c_compiler:
 - vs2019
 channel_sources:
@@ -16,3 +16,5 @@ openssl:
 - 1.1.1
 target_platform:
 - win-64
+zlib:
+- '1.2'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,8 @@
 MACOSX_SDK_VERSION:  # [osx and x86_64]
   - 10.12            # [osx and x86_64]
+
+# last working combination on v1.8.x branch
+aws_c_common:
+  - 0.6.2
+aws_c_event_stream:
+  - 0.2.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - aws-c-event-stream
     - libcurl
     - openssl
+    - zlib
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ source:
     - 0001-fix-libdir-for-deps.patch
 
 build:
-  # temporarily skip all builds to push new branch
-  skip: true
   number: 4
   run_exports:
     - {{ pin_subpackage("aws-sdk-cpp", max_pin="x.x.x") }}


### PR DESCRIPTION
I had been overzealous when pushing a new branch, already including a [rerender](https://github.com/conda-forge/aws-sdk-cpp-feedstock/commit/05bb0bee1e9771ed88aa411068900d7c947fa4b6).

Since 1.8 doesn't build with newer versions of the aws-stack anymore, let's see if we can get at least the last working version going again.