### PR TITLE
[v1.8.x] try to update pins

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
-- 0.6.2
+- 0.7.4
 aws_c_event_stream:
-- 0.2.7
+- 0.2.13
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,9 +1,9 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_c_common:
-- 0.6.2
+- 0.7.4
 aws_c_event_stream:
-- 0.2.7
+- 0.2.13
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
-- 0.6.2
+- 0.7.4
 aws_c_event_stream:
-- 0.2.7
+- 0.2.13
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,9 +3,9 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '10.12'
 aws_c_common:
-- 0.6.2
+- 0.7.4
 aws_c_event_stream:
-- 0.2.7
+- 0.2.13
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,9 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 aws_c_common:
-- 0.6.2
+- 0.7.4
 aws_c_event_stream:
-- 0.2.7
+- 0.2.13
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
-- 0.6.2
+- 0.7.4
 aws_c_event_stream:
-- 0.2.7
+- 0.2.13
 c_compiler:
 - vs2019
 channel_sources:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,7 @@
 MACOSX_SDK_VERSION:  # [osx and x86_64]
   - 10.12            # [osx and x86_64]
 
-# last working combination on v1.8.x branch
 aws_c_common:
-  - 0.6.2
+  - 0.7.4
 aws_c_event_stream:
-  - 0.2.7
+  - 0.2.13


### PR DESCRIPTION
The current global pins of the aws-c-* stack are too new for aws-sdk-cpp 1.8, but maybe we can get a bit closer still before things break.