### PR TITLE
Remove unnecessary dependencies on Windows.

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,6 +2,8 @@ aws_c_common:
 - 0.9.0
 aws_c_event_stream:
 - 0.3.2
+aws_checksums:
+- 0.1.17
 aws_crt_cpp:
 - 0.23.1
 c_compiler:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -4,6 +4,8 @@ aws_c_common:
 - 0.9.0
 aws_c_event_stream:
 - 0.3.2
+aws_checksums:
+- 0.1.17
 aws_crt_cpp:
 - 0.23.1
 c_compiler:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -2,6 +2,8 @@ aws_c_common:
 - 0.9.0
 aws_c_event_stream:
 - 0.3.2
+aws_checksums:
+- 0.1.17
 aws_crt_cpp:
 - 0.23.1
 c_compiler:

--- a/.ci_support/migrations/aws_crt_cpp0231.yaml
+++ b/.ci_support/migrations/aws_crt_cpp0231.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_crt_cpp:
-- 0.23.1
-migrator_ts: 1694038517.3246095

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -6,6 +6,8 @@ aws_c_common:
 - 0.9.0
 aws_c_event_stream:
 - 0.3.2
+aws_checksums:
+- 0.1.17
 aws_crt_cpp:
 - 0.23.1
 c_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -4,6 +4,8 @@ aws_c_common:
 - 0.9.0
 aws_c_event_stream:
 - 0.3.2
+aws_checksums:
+- 0.1.17
 aws_crt_cpp:
 - 0.23.1
 c_compiler:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,6 +2,8 @@ aws_c_common:
 - 0.9.0
 aws_c_event_stream:
 - 0.3.2
+aws_checksums:
+- 0.1.17
 aws_crt_cpp:
 - 0.23.1
 c_compiler:
@@ -12,10 +14,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-libcurl:
-- '8'
-openssl:
-- '3'
 target_platform:
 - win-64
 zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,9 @@ requirements:
     - ninja
     - make  # [unix]
   host:
+    - aws-c-common
+    - aws-c-event-stream
+    - aws-checksums
     - aws-crt-cpp
     - libcurl  # [not win]
     - openssl  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ff869c1cfa1e5f980881b4b495e5bde9e019b06ad38336001ab0d69c3ffe0386
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("aws-sdk-cpp", max_pin="x.x.x") }}
 
@@ -21,11 +21,9 @@ requirements:
     - ninja
     - make  # [unix]
   host:
-    - aws-c-common
-    - aws-c-event-stream
     - aws-crt-cpp
-    - libcurl
-    - openssl
+    - libcurl  # [not win]
+    - openssl  # [not win]
     - zlib
 
 test:


### PR DESCRIPTION
See https://github.com/microsoft/vcpkg/blob/e8c2a04eb7ca058b6e2f0e6e33c67fdbffeee846/ports/aws-sdk-cpp/vcpkg.json#L9-L32.

`libcurl` and `openssl` are not needed on Windows~~, and the `aws-c-*` libraries are imported by `aws-crt-cpp`~~.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
